### PR TITLE
build: add mpi lib dirs && lib64 dir

### DIFF
--- a/bagua-core-internal/build.rs
+++ b/bagua-core-internal/build.rs
@@ -55,14 +55,22 @@ fn main() {
     cpp_builder.include(bagua_data_path.join("include"));
     cpp_builder.build("src/lib.rs");
 
+    let mpi_lib_dirs = cmd_lib::run_fun!(bash -c "mpicxx --showme:libdirs").unwrap();
+    let mpi_lib_dirs: Vec<&str> = mpi_lib_dirs.split(' ').collect();
+    for mpi_lib_dir in mpi_lib_dirs.iter() {
+        println!("cargo:rustc-link-search={}", mpi_lib_dir);
+    }
     println!(
         "cargo:rustc-link-search=native={}",
         format!("{}/lib64", cuda_home)
     );
-
     println!(
         "cargo:rustc-link-search={}",
         bagua_data_path.join("lib").as_path().to_str().unwrap()
+    );
+    println!(
+        "cargo:rustc-link-search={}",
+        bagua_data_path.join("lib64").as_path().to_str().unwrap()
     );
     println!("cargo:rustc-link-lib=static=Al");
     println!("cargo:rustc-link-lib=mpi");


### PR DESCRIPTION
在centos 上编译的al路径是在lib64下面。另外就是centos上安装的mpi so不在系统目录，需要手动指定下