### PR TITLE
feat: make full precision decentralized op stateless

### DIFF
--- a/bagua-core-internal/src/comm_ops/decentralized_full_precision_synchronous.rs
+++ b/bagua-core-internal/src/comm_ops/decentralized_full_precision_synchronous.rs
@@ -1,6 +1,6 @@
 use crate::comm_ops::CommOpTrait;
 use crate::communicators::{BaguaCommunicator, BaguaHierarchicalCommunicator, NCCLGroupGuard};
-use crate::datatypes::{BaguaBucket, BaguaReductionOp, BaguaTensorRaw, RawBaguaTensor};
+use crate::datatypes::{BaguaBucket, BaguaTensor, BaguaReductionOp, BaguaTensorRaw, RawBaguaTensor};
 use crate::events::BaguaEventChannel;
 use crate::resource_pool::CUDA_DEVICE_MEMORY_POOL;
 use crate::{BaguaCommOpChannels, BaguaScheduledCommOp};
@@ -20,6 +20,7 @@ pub struct DecentralizedFullPrecisionSynchronous {
     pub peer_selection_mode: PeerSelectionMode,
     pub step: Mutex<usize>,
     pub communication_interval: usize,
+    pub peer_weight: BaguaTensor,
 }
 
 impl CommOpTrait for DecentralizedFullPrecisionSynchronous {
@@ -45,23 +46,13 @@ impl CommOpTrait for DecentralizedFullPrecisionSynchronous {
             },
         };
 
-        let t = &communication_tensor;
-        let peer_tensor_buffer = CUDA_DEVICE_MEMORY_POOL[t.raw.device_id]
-            .try_pull(t.raw.num_elem_allocated * t.raw.dtype.bytes())
-            .expect("cannot allocate gpu memory");
-        let mut peer_tensor = BaguaTensorRaw {
-            ptr: peer_tensor_buffer.ptr,
-            num_elem_allocated: t.raw.num_elem_allocated,
-            dtype: t.raw.dtype,
-            num_elem: t.raw.num_elem,
-            device_id: t.raw.device_id,
-            pool_allocations: vec![Arc::new(peer_tensor_buffer)],
-        };
-
         let peer_mode = &self.peer_selection_mode;
         let comm_interval = &self.communication_interval;
         let step = { *self.step.lock() };
 
+        let mut peer_guard = self.peer_weight.inner.write();
+        let mut peer_tensor = peer_guard.raw.as_mut();
+        
         self.communicator.execute_communication(
             &mut communication_tensor,
             true,
@@ -74,7 +65,7 @@ impl CommOpTrait for DecentralizedFullPrecisionSynchronous {
                             if step % comm_interval == 0 {
                                 peer_tensor.clone_from(&t.raw, c.stream_ptr);
                                 let _guard = NCCLGroupGuard::new();
-                                c.allreduce(&mut peer_tensor, BaguaReductionOp::SUM);
+                                c.allreduce(peer_tensor, BaguaReductionOp::SUM);
                                 peer_tensor.divide_inplace(stream_ptr, c.nranks as f32);
                             }
                         }
@@ -97,7 +88,7 @@ impl CommOpTrait for DecentralizedFullPrecisionSynchronous {
                             {
                                 let _guard = NCCLGroupGuard::new();
                                 c.send(&t.raw, peer_rank);
-                                c.recv(&mut peer_tensor, peer_rank);
+                                c.recv(peer_tensor, peer_rank);
                             }
                             peer_tensor.average_inplace(&t.raw, c.stream_ptr);
                         }
@@ -109,55 +100,42 @@ impl CommOpTrait for DecentralizedFullPrecisionSynchronous {
             },
         );
 
-        if step % comm_interval == 0 {
-            // TODO: move this to .then() python API instead of hard code this in op
-            let post_backward_comm_op = BaguaScheduledCommOp {
-                name: format!("post backward comm op for bucket {}", bucket.name),
-                bucket: bucket.clone(),
-                ops: vec![Arc::new(DecentralizedFullPrecisionSynchronousPostStep {
-                    communicator: self.communicator.clone(),
-                    result_weight: peer_tensor,
-                })],
-                event_channel: BaguaEventChannel::new("decentralized_post_backward"),
-            };
-
-            comm_op_channels
-                .not_waited_post_backward_events_sender
-                .send(post_backward_comm_op.event_channel.clone())
-                .expect("cannot send post backward event");
-            comm_op_channels
-                .post_backward_channel_sender
-                .send(post_backward_comm_op)
-                .expect("cannot send post backward op");
-        }
-
         *self.step.lock() += 1;
     }
 }
 
 #[derive(Debug)]
-pub struct DecentralizedFullPrecisionSynchronousPostStep {
+pub struct DecentralizedFullPrecisionSynchronousWriteback {
     pub communicator: BaguaCommunicator,
-    pub result_weight: BaguaTensorRaw,
+    pub peer_weight: BaguaTensor,
+    pub step: Mutex<usize>,
+    pub communication_interval: usize,
 }
 
-impl CommOpTrait for DecentralizedFullPrecisionSynchronousPostStep {
+impl CommOpTrait for DecentralizedFullPrecisionSynchronousWriteback {
     fn execute_background_communication(
         &self,
         bucket: Arc<BaguaBucket>,
-        _comm_op_channels: &BaguaCommOpChannels,
+        comm_op_channels: &BaguaCommOpChannels,
     ) {
         let bucket = bucket.inner.lock();
         let stream_ptr = self.communicator.stream_ptr();
         let mut communication_tensor = bucket.get_communication_tensor(stream_ptr, false, false);
+        let comm_interval = &self.communication_interval;
+        let step = { *self.step.lock() };
+        
         self.communicator.execute_communication(
             &mut communication_tensor,
             false,
             false,
             true,
             &mut |c, t| {
-                t.raw.clone_from(&self.result_weight, c.stream_ptr);
+                if step % comm_interval == 0 {
+                    t.raw.clone_from(self.peer_weight.inner.read().raw.as_ref(), c.stream_ptr);
+                }
             },
         );
+        
+        *self.step.lock() += 1;
     }
 }

--- a/bagua-core-internal/src/datatypes/mod.rs
+++ b/bagua-core-internal/src/datatypes/mod.rs
@@ -1109,53 +1109,62 @@ impl BaguaBucket {
         hierarchical: bool,
         peer_selection_mode: String,
         communication_interval: usize,
-        compression: Option<String>,
-        weight: Option<BaguaTensor>,
-        left_peer_weight: Option<BaguaTensor>,
-        right_peer_weight: Option<BaguaTensor>,
+        peer_weight: BaguaTensor,
     ) {
         let communicator =
             BaguaCommunicator::new(communicator_internode, communicator_intranode, hierarchical)
                 .expect("cannot create communicator");
-        let comm_op: Arc<dyn CommOpTrait + Send + Sync> = match compression {
-            None => Arc::new(DecentralizedFullPrecisionSynchronous {
-                communicator,
-                peer_selection_mode: match peer_selection_mode.as_str() {
-                    "all" => PeerSelectionMode::All,
-                    "shift_one" => PeerSelectionMode::ShiftOne,
-                    "ring" => PeerSelectionMode::Ring,
-                    &_ => {
-                         unimplemented!("unsupported peer_selection_mode for decentralized algorithm (should be `all`, `shift_one` or `ring`)")
-                    }
-                },
-                step: Default::default(),
-                communication_interval,
-                peer_weight: left_peer_weight.expect("missing parameter `left_peer_weight` for full precision decentralized algorithm"),
-            }),
-            Some(x) => match x.as_str() {
-               "MinMaxUInt8" => Arc::new(DecentralizedLowPrecisionSynchronous {
-                     communicator,
-                     peer_selection_mode: match peer_selection_mode.as_str() {
-                         "ring" => PeerSelectionMode::Ring,
-                         &_ => {
-                             unimplemented!("unsupported peer_selection_mode for low precision decentralized algorithm (should be `ring`)")
-                         }
-                     },
-                     step: Default::default(),
-                     communication_interval,
-                     compression_method: TensorCompressionMethod::MinMaxUInt8(
-                         MinMaxUInt8CompressionParameters {},
-                     ),
-                    weight: weight.expect("missing parameter `weight` for low precision decentralized algorithm"), 
-                    left_peer_weight: left_peer_weight.expect("missing parameter `left_peer_weight` for low precision decentralized algorithm"),
-                    right_peer_weight: right_peer_weight.expect("missing parameter `right_peer_weight` for low precision decentralized algorithm"),
-                }),
-                _ => {
-                    unimplemented!()
+        let comm_op: Arc<dyn CommOpTrait + Send + Sync> = Arc::new(DecentralizedFullPrecisionSynchronous {
+            communicator,
+            peer_selection_mode: match peer_selection_mode.as_str() {
+                "all" => PeerSelectionMode::All,
+                "shift_one" => PeerSelectionMode::ShiftOne,
+                "ring" => PeerSelectionMode::Ring,
+                &_ => {
+                     unimplemented!("unsupported peer_selection_mode for decentralized algorithm (should be `all`, `shift_one` or `ring`)")
                 }
-
             },
-        };
+            step: Default::default(),
+            communication_interval,
+            peer_weight,
+        });
+
+        self.inner.lock().comm_ops.push(comm_op);
+    }
+    
+    pub fn append_low_precision_decentralized_synchronous_op(
+        &mut self,
+        communicator_internode: Option<&BaguaSingleCommunicator>,
+        communicator_intranode: Option<&BaguaSingleCommunicator>,
+        hierarchical: bool,
+        peer_selection_mode: String,
+        communication_interval: usize,
+        compression: String,
+        weight: BaguaTensor,
+        left_peer_weight: BaguaTensor,
+        right_peer_weight: BaguaTensor,
+    ) {
+        let communicator =
+            BaguaCommunicator::new(communicator_internode, communicator_intranode, hierarchical)
+                .expect("cannot create communicator");
+        let comm_op: Arc<dyn CommOpTrait + Send + Sync> = Arc::new(DecentralizedLowPrecisionSynchronous {
+             communicator,
+             peer_selection_mode: match peer_selection_mode.as_str() {
+                 "ring" => PeerSelectionMode::Ring,
+                 &_ => {
+                     unimplemented!("unsupported peer_selection_mode for low precision decentralized algorithm (should be `ring`)")
+                 }
+             },
+             step: Default::default(),
+             communication_interval,
+             compression_method: TensorCompressionMethod::MinMaxUInt8(
+                 MinMaxUInt8CompressionParameters {},
+             ),
+             weight,
+             left_peer_weight,
+             right_peer_weight,
+        });
+        
         self.inner.lock().comm_ops.push(comm_op);
     }
     

--- a/bagua-core-internal/src/datatypes/mod.rs
+++ b/bagua-core-internal/src/datatypes/mod.rs
@@ -1108,7 +1108,6 @@ impl BaguaBucket {
         communicator_intranode: Option<&BaguaSingleCommunicator>,
         hierarchical: bool,
         peer_selection_mode: String,
-        communication_interval: usize,
         peer_weight: BaguaTensor,
     ) {
         let communicator =
@@ -1124,7 +1123,6 @@ impl BaguaBucket {
                 }
             },
             step: Default::default(),
-            communication_interval,
             peer_weight,
         });
 
@@ -1137,7 +1135,6 @@ impl BaguaBucket {
         communicator_intranode: Option<&BaguaSingleCommunicator>,
         hierarchical: bool,
         peer_selection_mode: String,
-        communication_interval: usize,
         compression: String,
         weight: BaguaTensor,
         left_peer_weight: BaguaTensor,
@@ -1154,8 +1151,6 @@ impl BaguaBucket {
                      unimplemented!("unsupported peer_selection_mode for low precision decentralized algorithm (should be `ring`)")
                  }
              },
-             step: Default::default(),
-             communication_interval,
              compression_method: TensorCompressionMethod::MinMaxUInt8(
                  MinMaxUInt8CompressionParameters {},
              ),

--- a/bagua-core-internal/src/datatypes/mod.rs
+++ b/bagua-core-internal/src/datatypes/mod.rs
@@ -1123,8 +1123,9 @@ impl BaguaBucket {
                 peer_selection_mode: match peer_selection_mode.as_str() {
                     "all" => PeerSelectionMode::All,
                     "shift_one" => PeerSelectionMode::ShiftOne,
+                    "ring" => PeerSelectionMode::Ring,
                     &_ => {
-                        unimplemented!("unsupported peer_selection_mode for decentralized algorithm (should be `all` or `shift_one`)")
+                         unimplemented!("unsupported peer_selection_mode for decentralized algorithm (should be `all`, `shift_one` or `ring`)")
                     }
                 },
                 step: Default::default(),

--- a/bagua-core-internal/src/lib.rs
+++ b/bagua-core-internal/src/lib.rs
@@ -335,42 +335,30 @@ impl BaguaCommBackend {
         Ok(())
     }
 
-    pub fn execute_post_backward_comm_ops(&self) -> Result<usize, BaguaCoreError> {
-        let mut num_ev = 0;
-        loop {
-            let comm_op = self.channels.post_backward_channel_receiver.try_recv();
-            match comm_op {
-                Ok(comm_op) => {
-                    tracing::debug!("received post step communication operation {:?}", comm_op);
-                    for op in &comm_op.ops {
-                        op.execute_background_communication(comm_op.bucket.clone(), &self.channels);
-                    }
-                    tracing::debug!("comm op executed: {:?}", comm_op);
-                    comm_op.event_channel.finish();
-                    tracing::debug!("comm op marked finished: {:?}", comm_op);
-                    num_ev += 1;
-                }
-                Err(_) => return Ok(num_ev),
-            }
-        }
-    }
 
-    pub fn wait_pending_post_backward_comm_ops(&self) -> Result<usize, BaguaCoreError> {
-        let mut num_ev = 0;
-        loop {
-            let ev = self
-                .channels
-                .not_waited_post_backward_events_receiver
-                .try_recv();
-            match ev {
-                Ok(x) => {
-                    tracing::debug!("waiting for comm ops event {:?}", x);
-                    x.wait();
-                    tracing::debug!("comm ops event {:?} finished", x);
-                    num_ev += 1;
-                }
-                Err(_) => return Ok(num_ev),
-            }
+    pub fn schedule_python_op(&self, comm_op: Arc<dyn CommOpTrait + Send + Sync>) -> Result<(), BaguaCoreError> {
+        let event_channel = BaguaEventChannel::new("sched_python_op");
+    
+        unsafe {
+            cpp::cpp!([]
+            {
+                CUDACHECK(cudaDeviceSynchronize());
+            });
         }
+
+        self.channels
+            .schedule_channel_sender
+            .send(BaguaScheduledCommOp {
+                name: format!("sched python op"),
+                ops: vec![comm_op],
+                bucket: self.ordered_buckets.front().unwrap().clone(),
+                event_channel: event_channel.clone(),
+            })
+            .map_err(|e| BaguaCoreError::InternalChannelError(format!("{:?}", e)))?;
+        Ok(self
+            .channels
+            .not_waited_events_sender
+            .send(event_channel)
+            .map_err(|e| BaguaCoreError::InternalChannelError(format!("{:?}", e)))?)
     }
 }

--- a/bagua-core-py/src/lib.rs
+++ b/bagua-core-py/src/lib.rs
@@ -379,6 +379,25 @@ impl BaguaBucketPy {
         );
         Ok(())
     }
+    
+    #[args(hierarchical = "false", communication_interval = "1")]
+    pub fn append_decentralized_synchronous_writeback_op(
+        &mut self,
+        communicator_internode: Option<&BaguaSingleCommunicatorPy>,
+        communicator_intranode: Option<&BaguaSingleCommunicatorPy>,
+        hierarchical: bool,
+        communication_interval: usize,
+        peer_weight: PyRef<BaguaTensorPy>,
+    ) -> PyResult<()> {
+        self.inner.append_decentralized_synchronous_writeback_op(
+            communicator_internode.map(|x| &x.inner),
+            communicator_intranode.map(|x| &x.inner),
+            hierarchical,
+            communication_interval,
+            (*peer_weight).inner.clone(),
+        );
+        Ok(())
+    }
 
     pub fn print_ops(&self) -> PyResult<()> {
         println!("{:?}", self.inner.inner.lock().comm_ops);

--- a/bagua-core-py/src/lib.rs
+++ b/bagua-core-py/src/lib.rs
@@ -410,7 +410,6 @@ impl BaguaBucketPy {
         communicator_intranode: Option<&BaguaSingleCommunicatorPy>,
         hierarchical: bool,
         peer_selection_mode: String,
-        communication_interval: usize,
         peer_weight: PyRef<BaguaTensorPy>,
     ) -> PyResult<()> {
         self.inner.append_decentralized_synchronous_op(
@@ -418,7 +417,6 @@ impl BaguaBucketPy {
             communicator_intranode.map(|x| &x.inner),
             hierarchical,
             peer_selection_mode,
-            communication_interval,
             (*peer_weight).inner.clone(),
         );
         Ok(())
@@ -431,7 +429,6 @@ impl BaguaBucketPy {
         communicator_intranode: Option<&BaguaSingleCommunicatorPy>,
         hierarchical: bool,
         peer_selection_mode: String,
-        communication_interval: usize,
         compression: String,
         weight: PyRef<BaguaTensorPy>,
         left_peer_weight: PyRef<BaguaTensorPy>,
@@ -442,7 +439,6 @@ impl BaguaBucketPy {
             communicator_intranode.map(|x| &x.inner),
             hierarchical,
             peer_selection_mode,
-            communication_interval,
             compression,
             (*weight).inner.clone(),
             (*left_peer_weight).inner.clone(),


### PR DESCRIPTION
BREAKING CHANGE: 

`BaguaBucketPy::append_decentralized_synchronous_op` now only supports full precision decentralized communication.